### PR TITLE
Fix webpack-dev-server hanging on recompile

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,10 +48,10 @@ OpenBrowserPlugin.prototype.apply = function(compiler) {
     }, delay);
   })
 
-  compiler.plugin('watch-run', once(function checkWatchingMode(watching, done) {
+  compiler.plugin('watch-run', function checkWatchingMode(watching, done) {
     isWatching = true;
     done();
-  }));
+  });
 
   compiler.plugin('done', function doneCallback(stats) {
     if (isWatching && (!stats.hasErrors() || ignoreErrors)) {


### PR DESCRIPTION
Fix issue #18 when webpack@2 hangs on "webpack: Compiling..."

Watcher should always run `done` callback for correct further work