### PR TITLE
Updated open package to fix critical NPM vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "open-browser-webpack-plugin",
+  "version": "0.0.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+    },
+    "open": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.3.0.tgz",
+      "integrity": "sha512-6AHdrJxPvAXIowO/aIaeHZ8CeMdDf7qCyRNq8NwJpinmCdXhz+NZR7ie1Too94lpciCDsG+qHGO9Mt0svA4OqA==",
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/baldore/webpack-open-plugin#readme",
   "dependencies": {
-    "open": "0.0.5"
+    "open": "^6.3.0"
   },
   "devDependencies": {
     "webpack": "^1.12.1"


### PR DESCRIPTION
There is a critical vulnerability in the `open` package, so I updated to the latest version. There are no breaking changes.